### PR TITLE
Change the minifier

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@ const buildEnv = require('./build')
 const copy = require('./copy')
 const replace = require('./replace')
 const webpack = require('webpack')
-const Minify = require('babel-minify-webpack-plugin')
+const Minify = require('terser-webpack-plugin')
 const Clean = require('clean-webpack-plugin')
 
 module.exports = {
@@ -18,7 +18,16 @@ module.exports = {
       new webpack.optimize.ModuleConcatenationPlugin(),
       copy.copyPlugin(projDir, options.copyOptions),
       replace.replacePlugin(projDir, options.replaceOptions),
-      new Minify()
+      new Minify({
+        parallel: true,
+        cache: true,
+        sourceMap: true,
+        terserOptions: {
+         output: {
+              ascii_only: true
+          }
+        }
+      })
     ]
 
     return {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "author": "Tim Keane",
   "license": "ISC",
   "dependencies": {
-    "babel-minify-webpack-plugin": "^0.3.1",
     "clean-webpack-plugin": "^0.1.19",
     "copy-webpack-plugin": "^4.5.2",
     "dotenv": "^6.0.0",
     "replace-in-file-webpack-plugin": "^1.0.6",
     "ssh2": "^0.6.1",
+    "terser-webpack-plugin": "1.1.0",
     "webpack": "^4.16.1",
     "zip-dir": "^1.0.2"
   }


### PR DESCRIPTION
@timkeane AFAICT the minify issue comes from ```babel-minify-webpack-plugin```

In ```create-react-app``` they have switched to using terser since uglify has issues and is unmaintained.

This PR does the same thing, it got rid of the error on build, but I haven't checked as yet if source maps are still working. Any chance you could verify that in your setup?

Another thing, it seems the client app and this project might run with different versions of webpack. I'm not 100% sure if that might cause issues, but it might be safer to keep them the same. If I match the versions at least they are getting deduped properly:

```
hurricane@0.4.27 /home/bartvde/opengeo/git/hurricane
├─┬ nyc-build-helper@0.0.23
│ └── webpack@4.22.0  deduped
└── webpack@4.22.0 
```

Let me know what you think.